### PR TITLE
feat: stabilize engine core and modularize splash components

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,23 +5,24 @@ from windfall.core import WindfallCore
 def main():
 	# 1. Initialize the components
 	tui = TUIRenderer()
-	core = WindfallCore()
+	core = WindfallCore(tui)
 	
 	tui.setup()
 	
 	try:
 		while core.running:
-			event = tui.get_input()
-			if event:
-				core.post_event(event)
+			# 1. Capture input
+			event = tui.get_input() 
+			if event: core.post_event(event)
 
-			core.update()
+			# 2. Run the logic pulse
+			core.update() 
 
-			# Render whatever scene is currently active
+			# 3. Draw the frame
 			if core.active_scene:
 				core.active_scene.render(tui)
 
-			time.sleep(0.03)
+			time.sleep(0.016)
 
 	except KeyboardInterrupt:
 		pass

--- a/windfall/core.py
+++ b/windfall/core.py
@@ -1,33 +1,42 @@
 from collections import deque
 from .events import WindfallEvent, EventType
-from windfall.scenes.menu import MainMenuScene # We'll create this next
+from windfall.scenes.splash import SplashScene
 
 class WindfallCore:
-    def __init__(self):
-        self.running = True
-        self.event_queue: deque[WindfallEvent] = deque()
-        
-        # New: The Scene Stack
-        # We initialize with the MainMenuScene
-        self.scene_stack = [MainMenuScene(self)]
+	def __init__(self, renderer):
+		self.renderer = renderer
+		self.scene_stack = [SplashScene(self)]
+		self.running = True
+		self.event_queue: deque[WindfallEvent] = deque()
+		
+		# Start with Splash instead of Menu to trigger the boot sequence
+		self.scene_stack = [SplashScene(self)]
 
-    @property
-    def active_scene(self):
-        """Returns the scene currently at the top of the stack."""
-        return self.scene_stack[-1] if self.scene_stack else None
+	@property
+	def active_scene(self):
+		"""Returns the scene currently at the top of the stack."""
+		return self.scene_stack[-1] if self.scene_stack else None
 
-    def post_event(self, event: WindfallEvent):
-        self.event_queue.append(event)
+	def post_event(self, event: WindfallEvent):
+		self.event_queue.append(event)
 
-    def update(self):
-        while self.event_queue:
-            event = self.event_queue.popleft()
+	def update(self):
+		# Phase 1: Clear the event queue (Input)
+		while self.event_queue:
+			event = self.event_queue.popleft()
+			if event.type == EventType.QUIT:
+				self.running = False
+				return
+			if self.active_scene:
+				self.active_scene.handle_input(event) # This handles your 'Enter' skip
 
-            # 1. Global Engine Events (Priority)
-            if event.type == EventType.QUIT:
-                self.running = False
-                return
-
-            # 2. Delegate to the Active Scene
-            if self.active_scene:
-                self.active_scene.handle_input(event)
+		# Phase 2: Logic Pulse (Timers/Animations)
+		# THIS MUST BE OUTSIDE THE WHILE LOOP
+		if self.active_scene:
+			self.active_scene.update()
+				
+	def change_scene(self, new_scene):
+		"""Replaces the entire stack with the new scene."""
+		self.scene_stack = [new_scene]
+		# Clear the screen once during the transition to prevent ghosting
+		print(self.renderer.term.clear, end="")

--- a/windfall/events.py
+++ b/windfall/events.py
@@ -10,6 +10,8 @@ class EventType(Enum):
     # Input/Navigation Events
     MENU_UP = auto()
     MENU_DOWN = auto()
+    MENU_LEFT = auto()
+    MENU_RIGHT = auto()
     MENU_SELECT = auto()
 
 @dataclass

--- a/windfall/scenes/menu.py
+++ b/windfall/scenes/menu.py
@@ -2,27 +2,85 @@ from windfall.scenes.base import BaseScene
 from windfall.core import EventType
 
 class MainMenuScene(BaseScene):
-    def __init__(self, core):
-        super().__init__(core)
-        self.options = ["Start Game", "Options", "Exit"]
-        self.selected_index = 0
+	def __init__(self, core):
+		super().__init__(core)
+		# 0 = LIBRARY (Left), 1 = FORGE (Right)
+		self.selection = 0 
+		self.options = ["LIBRARY", "FORGE"]
 
-    def handle_input(self, event):
-        if event.type == EventType.MENU_UP:
-            self.selected_index = max(0, self.selected_index - 1)
-        elif event.type == EventType.MENU_DOWN:
-            self.selected_index = min(len(self.options) - 1, self.selected_index + 1)
-        elif event.type == EventType.MENU_SELECT:
-            self._handle_selection()
+	def update(self):
+		# The menu always needs input to function
+		event = self.core.renderer.get_input()
+		if event:
+			self.handle_input(event)
 
-    def _handle_selection(self):
-        selection = self.options[self.selected_index].lower()
-        if "exit" in selection:
-            from windfall.core import WindfallEvent, EventType
-            self.core.post_event(WindfallEvent(EventType.QUIT))
-        elif "start" in selection:
-            # We'll add scene switching logic here next!
-            pass
+	def handle_input(self, event):
+		"""Processes A/D for horizontal navigation and ENTER for selection."""
+		if event.type == EventType.MENU_LEFT:
+			self.selection = 0
+		elif event.type == EventType.MENU_RIGHT:
+			self.selection = 1
+		elif event.type == EventType.MENU_SELECT:
+			self._execute_selection()
+		elif event.type == EventType.QUIT:
+			from windfall.core import WindfallEvent
+			self.core.post_event(WindfallEvent(EventType.QUIT))
 
-    def render(self, renderer):
-        renderer.render_menu(self.options, self.selected_index)
+	def _execute_selection(self):
+		"""Determines which shard to 'Jack-in' to."""
+		if self.selection == 0:
+			# TODO: Transition to Library Scene
+			pass
+		elif self.selection == 1:
+			# TODO: Transition to Forge/Wizard Scene
+			pass
+
+	def render(self, renderer):
+		print(renderer.term.home, end="")
+		term = renderer.term
+
+		# Center coordinates
+		mid_x = term.width // 2
+		mid_y = term.height // 2
+
+		# --- DRAW HEADER (Cyan) ---
+		header = "=== WINDFALL SYSTEM DECK ==="
+		renderer.draw_at(mid_x - len(header)//2, mid_y - 8, header, color=term.bold_cyan)
+
+		# --- DRAW OPTION 1: LIBRARY (Teal) ---
+		# If selected (0), use Yellow. If not, use Teal.
+		lib_color = term.bold_yellow if self.selection == 0 else term.teal
+		lib_box = [
+			"╔═══════════════╗",
+
+			"║    LIBRARY    ║",
+
+			"╚═══════════════╝"
+		]
+
+		for i, line in enumerate(lib_box):
+			renderer.draw_at(mid_x - 25, mid_y - 1 + i, line, color=lib_color)
+
+		# --- DRAW OPTION 2: FORGE (Magenta) ---
+		# If selected (1), use Yellow. If not, use Magenta.
+		forge_color = term.bold_yellow if self.selection == 1 else term.magenta
+		forge_box = [
+			"╔═══════════════╗",
+
+			"║     FORGE     ║",
+
+			"╚═══════════════╝"
+		]
+
+		for i, line in enumerate(forge_box):
+			renderer.draw_at(mid_x + 5, mid_y - 1 + i, line, color=forge_color)
+
+		# --- DRAW DATA CABLE (Green) ---
+		# This draws a line from the header to the selected box
+		target_x = (mid_x - 17) if self.selection == 0 else (mid_x + 13)
+		renderer.draw_at(target_x, mid_y - 5, "║", color=term.green)
+		renderer.draw_at(target_x, mid_y - 4, "▼", color=term.green)
+
+		# --- FOOTER ---
+		footer = "A / D to Navigate | ENTER to Jack-In"
+		renderer.draw_at(mid_x - len(footer)//2, term.height - 3, footer, color=term.darkgray)

--- a/windfall/scenes/splash.py
+++ b/windfall/scenes/splash.py
@@ -1,0 +1,119 @@
+import time
+from windfall.scenes.base import BaseScene
+from windfall.events import EventType
+
+# --- UI COMPONENTS ---
+
+class SplashLogo:
+    def __init__(self):
+        self.alpha = 0.0  # Float for smooth math
+        self.lines = [
+            r" _      _           _  __        _  _ ",
+            r"| | _  (_)_ __   __| |/ _| __ _ | || |",
+            r"| |/ \ | | '_ \ / _` | |_ / _` || || |",
+            r"| |\  || | | | | (_| |  _| (_| || || |",
+            r"|_| \_||_|_| |_|\__,_|_|  \__,_||_||_|"
+        ]
+        self.width = 38
+
+    def update(self):
+        if self.alpha < 1.0:
+            self.alpha += 0.015
+
+    def render(self, renderer, x, y):
+        # Calculate fade color
+        intensity = int(255 * max(0.0, min(1.0, self.alpha)))
+        cyan_fade = renderer.term.color_rgb(0, intensity, intensity)
+        
+        for i, line in enumerate(self.lines):
+            renderer.draw_at(x, y + i, line, color=cyan_fade)
+
+class ProgressBar:
+    def __init__(self, width):
+        self.width = width
+        self.progress = 0.0
+
+    def update(self, elapsed, duration=4.0):
+        self.progress = min(1.0, elapsed / duration)
+
+    def render(self, renderer, x, y):
+        filled_size = int(self.width * self.progress)
+        bar_text = "█" * filled_size + "░" * (self.width - filled_size)
+        # Explicitly set to Magenta to prevent color bleed
+        renderer.draw_at(x, y, bar_text, color=renderer.term.magenta)
+
+class DiagnosticLogger:
+    def __init__(self, boot_logs):
+        self.all_logs = boot_logs
+        self.active_logs = []
+        self.index = 0
+        self.last_log_time = 0
+
+    def update(self, elapsed):
+        # Start logs after 0.8s delay
+        if elapsed > 0.8 and self.index < len(self.all_logs):
+            if time.time() - self.last_log_time > 0.3:
+                self.active_logs.append(self.all_logs[self.index])
+                self.index += 1
+                self.last_log_time = time.time()
+
+    def render(self, renderer, x, y):
+        for i, log in enumerate(self.active_logs[-3:]):
+            # Overwrite line to prevent ghosting
+            clean_log = log.ljust(renderer.term.width - 10)
+            log_color = renderer.term.green if "OK" in log else renderer.term.yellow
+            renderer.draw_at(x, y + i, clean_log, color=log_color)
+
+# --- MAIN SCENE ---
+
+class SplashScene(BaseScene):
+    def __init__(self, core):
+        super().__init__(core)
+        self.start_time = time.time()
+        
+        # Initialize sub-components
+        self.logo = SplashLogo()
+        self.progress_bar = ProgressBar(width=38)
+        self.logger = DiagnosticLogger([
+            "[ OK ] MOUNTING VIRTUAL FILESYSTEM...",
+            "[ OK ] SYNCING NEURAL CORE [CYAN_PROTOCOL]...",
+            "[ OK ] SCANNING LIBRARY SECTORS...",
+            "[ !! ] WARNING: UNREGISTERED SHARDS DETECTED.",
+            "[ OK ] INITIALIZING WINDFALL ENGINE...",
+            "[ >> ] HANDSHAKE SUCCESS. WELCOME, ARCHITECT."
+        ])
+
+    def update(self):
+        elapsed = time.time() - self.start_time
+
+        # Update all component logic
+        self.logo.update()
+        self.progress_bar.update(elapsed)
+        self.logger.update(elapsed)
+
+        # Auto-Transition logic
+        if elapsed > 4.5:
+            self._transition()
+
+    def handle_input(self, event):
+        # Allow skipping with Enter
+        if event.type == EventType.MENU_SELECT:
+            self._transition()
+
+    def render(self, renderer):
+        # Use home instead of clear to prevent flicker
+        print(renderer.term.home, end="")
+        
+        term = renderer.term
+        # Shared positioning math
+        lx = (term.width // 2) - (self.logo.width // 2)
+        ly = (term.height // 2) - 5
+
+        # Render each piece
+        self.logo.render(renderer, lx, ly)
+        self.progress_bar.render(renderer, lx, ly + 6)
+        self.logger.render(renderer, 4, term.height - 4)
+
+    def _transition(self):
+        from windfall.scenes.menu import MainMenuScene
+        self.core.change_scene(MainMenuScene(self.core))


### PR DESCRIPTION
- Fixed color bleeding with terminal reset logic
- Modularized Splash into Logo, ProgressBar, and Logger components
- Fixed main menu flicker using home() instead of clear()
- Implemented auto-transition and 'Q' to quit logic